### PR TITLE
Updated PAHdb fitting uncertainty estimation

### DIFF
--- a/amespahdbpythonsuite/fitted.py
+++ b/amespahdbpythonsuite/fitted.py
@@ -415,7 +415,9 @@ class Fitted(Spectrum):
         nc = np.array([self.atoms[uid]['nc'] for uid in self.uids])
         breakdown['nc'] = np.sum(nc * fweight) / np.sum(fweight)
         # Getting fit uncertainty.
-        breakdown['error'] = self.__geterror()
+        pahdberr = self.__geterror()
+        for key in pahdberr.keys():
+            breakdown[key] = pahdberr[key]
 
         return breakdown
 
@@ -507,6 +509,8 @@ class Fitted(Spectrum):
         if self.observation:
             for key in piecewise.keys():
                 sel = np.where(np.logical_and(self.grid >= range[key][0], self.grid <= range[key][1]))[0]
-                total_area = np.trapz(self.observation[sel], x=self.grid[sel])
-                resid_area = np.trapz(np.abs(self.observation[sel] - self.getfit()[sel]), x=self.grid[sel])
+                total_area = np.trapz(np.array(self.observation)[sel], x=self.grid[sel])
+                resid_area = np.trapz(np.abs(np.array(self.observation)[sel] - self.getfit()[sel]),
+                                      x=self.grid[sel])
                 piecewise[key] = resid_area / total_area
+            return piecewise

--- a/amespahdbpythonsuite/fitted.py
+++ b/amespahdbpythonsuite/fitted.py
@@ -492,7 +492,21 @@ class Fitted(Spectrum):
         as the ratio of the residual over the total spectrum area.
 
         """
+        tags = ['err', 'e127', 'e112', 'e77', 'e62', 'e33']
+
+        piecewise = dict.fromkeys(tags)
+
+        range = dict.fromkeys(tags)
+        range['err'] = [min(self.grid), max(self.grid)]
+        range['e127'] = [754.0, 855.0]
+        range['e112'] = [855.0, 1000.0]
+        range['e77'] = [1000.0, 1495.0]
+        range['e62'] = [1495.0, 1712.0]
+        range['e33'] = [2900.0, 3125.0]
+
         if self.observation:
-            total_area = np.trapz(self.observation, x=self.grid)
-            resid_area = np.trapz(np.abs(self.getresidual()), x=self.grid)
-            return resid_area / total_area
+            for key in piecewise.keys():
+                sel = np.where(np.logical_and(self.grid >= range[key][0], self.grid <= range[key][1]))[0]
+                total_area = np.trapz(self.observation[sel], x=self.grid[sel])
+                resid_area = np.trapz(np.abs(self.observation[sel] - self.getfit()[sel]), x=self.grid[sel])
+                piecewise[key] = resid_area / total_area

--- a/amespahdbpythonsuite/tests/test_fitted.py
+++ b/amespahdbpythonsuite/tests/test_fitted.py
@@ -88,5 +88,7 @@ class TestFitted():
         # Obtain fit breakdown.
         bd = fit.getbreakdown()
         lkeys = ['solo', 'duo', 'trio', 'quartet', 'quintet',
-                 'anion', 'neutral', 'cation', 'small', 'large', 'nitrogen', 'pure', 'nc', 'error']
+                 'anion', 'neutral', 'cation', 'small', 'large',
+                 'nitrogen', 'pure', 'nc', 'err',
+                 'e127', 'e112', 'e77', 'e62', 'e33']
         assert list(bd.keys()) == lkeys


### PR DESCRIPTION
Updated the __geterror method to return a dictionary containing the total PAHdb fitting uncertainty, as well as per band uncertainties in the 12.7, 11.2, 7.7, 6.2, and 3.3 μm PAH band wavelength range.