### PR TITLE
Monte Carlo implementation

### DIFF
--- a/amespahdbpythonsuite/mcfitted.py
+++ b/amespahdbpythonsuite/mcfitted.py
@@ -12,7 +12,7 @@ from amespahdbpythonsuite.spectrum import Spectrum
 message = AmesPAHdb.message
 
 
-class Mcfitted(Spectrum):
+class MCfitted:
     """
     AmesPAHdbPythonSuite mcfitted class.
     Contains methods to fit and plot the input spectrum using a Monte Carlo approach.
@@ -20,7 +20,6 @@ class Mcfitted(Spectrum):
     """
 
     def __init__(self, d: Optional[dict] = None, **keywords) -> None:
-        super().__init__(d, **keywords)
         self.__set(d, **keywords)
 
     def set(self, d: Optional[dict] = None, **keywords) -> None:
@@ -38,28 +37,16 @@ class Mcfitted(Spectrum):
         """
         if isinstance(d, dict):
             if d.get("type", "") == self.__class__.__name__:
-                if "observation" not in keywords:
-                    self.observation = d["observation"]
                 if "mcfits" not in keywords:
                     self.mcfits = d["mcfits"]
-                if "mcweights" not in keywords:
-                    self.mcweights = d["mcweights"]
-                if "mcclasses" not in keywords:
-                    self.mcclasses = d["mcclasses"]
-                if "mcresults" not in keywords:
-                    self.mcresults = d["mcresults"]
                 if "mcpredicted" not in keywords:
                     self.mcpredicted = d["mcpredicted"]
-                if "method" not in keywords:
-                    self.method = d["method"]
+                if "distribution" not in keywords:
+                    self.distribuion = d["distribuion"]
 
-        self.observation = keywords.get("observation", None)
         self.mcfits = keywords.get("mcfits", list())
-        self.mcweights = keywords.get("mcweights", list())
-        self.mcclasses = keywords.get("mcclasses", list())
-        self.mcresults = keywords.get("mcresults", list())
         self.mcpredicted = keywords.get("mcpredicted", False)
-        self.method = keywords.get("method", "")
+        self.distribution = keywords.get("distribution", "")
 
     def get(self) -> dict:
         """
@@ -69,37 +56,46 @@ class Mcfitted(Spectrum):
         """
         d = Spectrum.get(self)
         d["type"] = self.__class__.__name__
-        d["observation"] = self.observation
         d["mcfits"] = self.mcfits
-        d["mcweights"] = self.mcweights
-        d["mcclasses"] = self.mcclasses
-        d["mcresults"] = self.mcresults
         d["mcpredicted"] = self.mcpredicted
-        d["method"] = self.method
+        d["distribution"] = self.distribution
 
         return d
 
-    def stats(self, results):
+    def getstats(self, save=False, **keywords):
         """
         Obtain statistics (min, max, median, mean, std) for the MC fitted parameters,
         and save to file.
 
         """
 
-        # Save MC breakdown stats to file.
-        o = open('mcfitted_statistics.txt', 'w')
-        o.write('# param min max median mean std\n')
+        if 'results' not in keywords:
+            results = self.getbreakdown()
 
         rkeys = list(results.keys())
-        for i, key in enumerate(rkeys):
-            o.write(f'{key} {np.min(results[key]):.5f} '
-                    f'{np.max(results[key]):.5f} '
-                    f'{np.median(results[key]):.5f} '
-                    f'{np.mean(results[key]):.5f} '
-                    f'{np.std(results[key]):.5f}\n')
-        o.close()
 
-    def averagespec(self, mcfits, mcclasses, **keywords):
+        if save:
+            # Save MC breakdown stats to file.
+            o = open('mcfitted_statistics.txt', 'w')
+            o.write('# param min max median mean std\n')
+
+            for i, key in enumerate(rkeys):
+                o.write(f'{key} {np.min(results[key]):.5f} '
+                        f'{np.max(results[key]):.5f} '
+                        f'{np.median(results[key]):.5f} '
+                        f'{np.mean(results[key]):.5f} '
+                        f'{np.std(results[key]):.5f}\n')
+            o.close()
+        else:
+            print('# param min max median mean std')
+            for i, key in enumerate(rkeys):
+                print(f'{key} {np.min(results[key]):.5f} '
+                      f'{np.max(results[key]):.5f} '
+                      f'{np.median(results[key]):.5f} '
+                      f'{np.mean(results[key]):.5f} '
+                      f'{np.std(results[key]):.5f}')
+
+    def averagespec(self, **keywords):
         """
         Calculate average and std spectra.
 
@@ -110,24 +106,24 @@ class Mcfitted(Spectrum):
         avg_classes = {}
         std_classes = {}
 
-        # Average and std spectrum.
-        avg_fit = np.mean(mcfits, axis=0)
-        std_fit = np.std(mcfits, axis=0)
-
-        if 'mcpredicted' in keywords:
-            avg_pred = np.mean(self.mcpredicted, axis=0)
-            std_pred = np.std(self.mcpredicted, axis=0)
-            components['predicted'] = {'mean_spec': avg_pred, 'std_spec': std_pred}
+        # Get average and std spectrum.
+        if 'fits' not in keywords:
+            fits = self.getfit()
+        avg_fit = np.mean(fits, axis=0)
+        std_fit = np.std(fits, axis=0)
 
         components['fit'] = {'mean_spec': avg_fit, 'std_spec': std_fit}
 
-        classkeys = ['anion', 'neutral', 'cation', 'small', 'large', 'nitrogen', 'pure']
+        # Get average and std spectrum of classes.
+        if 'classes' not in keywords:
+            classes = self.getclasses()
+        classkeys = list(classes[0].keys())
 
         for key in classkeys:
             lst_classes[key] = []
             avg_classes[key] = []
             std_classes[key] = []
-        for c in mcclasses:
+        for c in classes:
             for key in classkeys:
                 if key in c.keys():
                     lst_classes[key].append(c[key])
@@ -136,33 +132,94 @@ class Mcfitted(Spectrum):
             std_classes[key] = np.std(lst_classes[key], axis=0)
             components[key] = {'mean_spec': avg_classes[key], 'std_spec': std_classes[key]}
 
-        # Dump average components pickle
-        if 'dump' in keywords:
-            import pickle
-            pickle.dump(components, open('average_mc_spectra.pkl', 'wb'))
+        if 'predicted' in keywords:
+            avg_pred = np.mean(self.mcpredicted, axis=0)
+            std_pred = np.std(self.mcpredicted, axis=0)
+            components['predicted'] = {'mean_spec': avg_pred, 'std_spec': std_pred}
 
         return components
 
-    def plot(self, components, **keywords):
+    def getfit(self, **keywords) -> list:
+        """
+        Retrieves the sum of fit values.
+
+        """
+        fits = []
+        for fit in self.mcfits:
+            fits.append(fit.getfit())
+
+        return fits
+
+    def getbreakdown(self, **keywords) -> dict:
+        """
+        Retrieves the breakdown of the MC fitted PAHs.
+
+        """
+        results = {'solo': [],
+                   'duo': [],
+                   'trio': [],
+                   'quartet': [],
+                   'quintet': [],
+                   'anion': [],
+                   'neutral': [],
+                   'cation': [],
+                   'small': [],
+                   'large': [],
+                   'nitrogen': [],
+                   'pure': [],
+                   'nc': [],
+                   'error': []
+                   }
+
+        keys = list(results.keys())
+
+        # Obtain fit breakdown.
+        for fit in self.mcfits:
+            bd = fit.getbreakdown()
+            for key in keys[:-1]:
+                results[key].append(bd[key])
+            # Obtain fit uncertainty.
+            error = fit.geterror()['err']
+            results['error'].append(error)
+
+        return results
+
+    def getclasses(self, **keywords) -> list:
+        """
+        Retrieves the spectra of the different classes of the MC fitted PAHs.
+
+        """
+        self.mcclasses = []
+        for fit in self.mcfits:
+            self.mcclasses.append(fit.getclasses())
+
+        return self.mcclasses
+
+    def plot(self, **keywords):
         """
         Plot the MC sampled fit and breakdown components.
 
         """
+        from astropy.nddata import StdDevUncertainty  # type: ignore
+
+        obs = self.mcfits[0].observation
+        units = self.mcfits[0].units
+
+        if 'components' not in keywords:
+            components = self.averagespec()
 
         # Charge
         fig, ax = plt.subplots()
 
-        if 'wavelength' in keywords:
-            x = 1e4 / self.grid
-            ax.set_xlim((min(x), max(x)))
-            xtitle = "Wavelength"
+        if keywords.get('wavelength', False):
+            x = 1e4 / obs.spectral_axis.value
+            xtitle = "Wavelength [micron]"
         else:
-            x = self.grid
-            ax.set_xlim((max(x), min(x)))
+            x = obs.spectral_axis.value
             xtitle = (
-                self.units["abscissa"]["label"]
+                units["abscissa"]["label"]
                 + " ["
-                + self.units["abscissa"]["unit"].to_string("latex_inline")
+                + units["abscissa"]["unit"].to_string("latex_inline")
                 + "]"
             )
 
@@ -172,32 +229,41 @@ class Mcfitted(Spectrum):
         ax.set_xlim((min(x), max(x)))
         ax.set_xlabel(f"{xtitle}")
         ax.set_ylabel(
-            self.units["ordinate"]["label"]
+            units["ordinate"]["label"]
             + " ["
-            + self.units["ordinate"]["unit"].to_string("latex_inline")
+            + units["ordinate"]["unit"].to_string("latex_inline")
             + "]",
         )
 
-        ax.errorbar(
-            x,
-            self.observation.spectrum.flux.value,
-            yerr=keywords["sigma"],
-            fmt="o",
-            mfc="white",
-            color="k",
-            ecolor="k",
-            markersize=3,
-            elinewidth=0.2,
-            capsize=0.8,
-            label="obs",
-        )
+        if isinstance(obs.uncertainty, StdDevUncertainty):
+            ax.errorbar(x,
+                        obs.flux.value,
+                        yerr=obs.uncertainty.array,
+                        fmt="o",
+                        mfc="white",
+                        color="k",
+                        ecolor="k",
+                        markersize=3,
+                        elinewidth=0.2,
+                        capsize=0.8,
+                        label="obs"
+                        )
+
+        else:
+            ax.scatter(x,
+                       obs.flux.value,
+                       color='k',
+                       s=10,
+                       label='obs'
+                       )
 
         ax.plot(x, components['fit']['mean_spec'], color='tab:purple', linewidth=1.2, label='fit')
         ax.fill_between(x, components['fit']['mean_spec'] - components['fit']['std_spec'],
                         components['fit']['mean_spec'] + components['fit']['std_spec'],
                         color='tab:purple', alpha=0.3)
 
-        if 'charge' in keywords:
+        if keywords.get('charge'):
+            ptype = 'charge'
             if isinstance(components['anion']['mean_spec'], np.ndarray):
                 ax.plot(x, components['anion'], color='tab:red', linewidth=1.2, label='anion')
                 ax.fill_between(x, components['anion']['mean_spec'] - components['anion']['std_spec'],
@@ -216,7 +282,8 @@ class Mcfitted(Spectrum):
                                 components['cation']['mean_spec'] + components['cation']['std_spec'],
                                 color='tab:blue', alpha=0.3)
 
-        if 'size' in keywords:
+        if keywords.get('size'):
+            ptype = 'size'
             if isinstance(components['small']['mean_spec'], np.ndarray):
                 ax.plot(x, components['small']['mean_spec'], color='tab:red', label='small')
                 ax.fill_between(x, components['small']['mean_spec'] - components['small']['std_spec'],
@@ -229,7 +296,8 @@ class Mcfitted(Spectrum):
                                 components['large']['mean_spec'] + components['large']['std_spec'],
                                 color='tab:green', alpha=0.3)
 
-        if 'composition' in keywords:
+        if keywords.get('composition'):
+            ptype = 'composition'
             if isinstance(components['pure']['mean_spec'], np.ndarray):
                 ax.plot(x, components['pure']['mean_spec'], color='tab:red', label='pure')
                 ax.fill_between(x, components['pure']['mean_spec'] - components['pure']['std_spec'],
@@ -243,14 +311,13 @@ class Mcfitted(Spectrum):
                                 color='tab:green', alpha=0.3)
 
         ax.axhline(0, linestyle='--', color='gray')
-        ax.legend(fontsize=12)
+        ax.legend(fontsize=10)
 
-        basename = keywords['ptype']
-        if basename:
-            if not isinstance(basename, str):
-                basename = 'fitted'
-            fig.savefig(f"mc_{keywords['ptype']}_breakdown.{keywords['ftype']}")
-        elif 'show' in keywords:
+        if keywords.get('save'):
+            if not isinstance(ptype, str):
+                ptype = 'fitted'
+            fig.savefig(f"mc_{ptype}_breakdown.pdf")
+        else:
             plt.show()
 
         plt.close(fig)

--- a/amespahdbpythonsuite/mcfitted.py
+++ b/amespahdbpythonsuite/mcfitted.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional, Union
+
+import numpy as np
+
+from specutils import Spectrum1D, manipulation  # type: ignore
+from astropy.nddata import StdDevUncertainty  # type: ignore
+import astropy.units as u  # type: ignore
+from scipy import optimize  # type: ignore
+
+from amespahdbpythonsuite.amespahdb import AmesPAHdb
+from amespahdbpythonsuite.transitions import Transitions
+
+if TYPE_CHECKING:
+    from amespahdbpythonsuite.coadded import Coadded
+    from amespahdbpythonsuite.fitted import Fitted
+
+
+message = AmesPAHdb.message
+
+
+class Mcfitted(Transitions):
+    """
+    AmesPAHdbPythonSuite mcfitted class.
+    Contains methods to fit and plot the input spectrum using a Monte Carlo approach.
+
+    """
+
+    def __init__(self, d: Optional[dict] = None, **keywords) -> None:
+        super().__init__(d, **keywords)
+        self.__set(d, **keywords)
+
+    def set(self, d: Optional[dict] = None, **keywords) -> None:
+        """
+        Calls class: :class:`amespahdbpythonsuite.transitions.Transitions.set` to parse keywords.
+
+        """
+        Transitions.set(self, d, **keywords)
+        self.__set(d, **keywords)
+
+    def __set(self, d: Optional[dict] = None, **keywords) -> None:
+        """
+        Populate data dictionary helper.
+
+        """
+        if isinstance(d, dict):
+            if d.get("type", "") == self.__class__.__name__:
+                if "grid" not in keywords:
+                    self.grid = d["grid"]
+                if "profile" not in keywords:
+                    self.profile = d["profile"]
+                if "fwhm" not in keywords:
+                    self.fwhm = d["fwhm"]
+
+        self.grid = keywords.get("grid", list())
+        self.profile = keywords.get("profile", "")
+        self.fwhm = keywords.get("fwhm", 0.0)
+
+    def get(self) -> dict:
+        """
+        Calls class: :class:`amespahdbpythonsuite.transitions.Transitions.get`.
+        Assigns class variables from inherited dictionary.
+
+        """
+        d = Transitions.get(self)
+        d["type"] = self.__class__.__name__
+        d["grid"] = self.grid
+        d["profile"] = self.profile
+        d["fwhm"] = self.fwhm
+
+        return d
+
+    def stats(self, results):
+        """
+        Obtain statistics (min, max, median, mean, std) for the MC fitted parameters.
+
+        """
+
+        # Save MC breakdown stats to file.
+        o = open('mcfitted_statistics.txt', 'w')
+        o.write('# param min max median mean std\n')
+
+        keys = list(results.keys())
+        for i, key in enumerate(keys):
+            if i < 5:
+                o.write(f'{key} {np.min(results[key]):d} {np.max(results[key]):d} {np.median(results[key]):.5f} {np.mean(results[key]):.5f} {np.std(results[key]):.5f}\n')
+            else:
+                o.write(f'{key} {np.min(results[key]):.5f} {np.max(results[key]):.5f} {np.median(results[key]):.5f} {np.mean(results[key]):.5f} {np.std(results[key]):.5f}\n')
+        o.close()
+
+    def averagespec(self, fits, classes, weights):
+        import pickle
+        #  Getting the average spectra
+        components = {}
+        lst_classes = {}
+        avg_classes = {}
+        std_classes = {}
+
+        # Average and std spectrum of fitted and predicted spectra.
+        avg_fit = np.mean(fits, axis=0)
+        std_fit = np.std(fits, axis=0)
+
+        components['fit'] = {'mean_spec': avg_fit, 'std_spec': std_fit}
+
+        classkeys = ['anion', 'neutral', 'cation', 'small', 'large', 'nitrogen', 'pure']
+
+        for key in classkeys:
+            lst_classes[key] = []
+            avg_classes[key] = []
+            std_classes[key] = []
+        for c in classes:
+            for key in classkeys:
+                lst_classes[key].append(c[key])
+        for key in classkeys:
+            avg_classes[key] = np.mean(lst_classes[key], axis=0)
+            std_classes[key] = np.std(lst_classes[key], axis=0)
+            components[key] = {'mean_spec': avg_classes[key], 'std_spec': std_classes[key]}
+
+        # Dump average components pickle
+        pickle.dump(components, open('average_mc_spectra.pkl', 'wb'))
+
+        # Calculate average weights.
+        luids = [d['uid'] for d in weights]
+        unq_uids = np.unique([item for sublist in luids for item in sublist])
+        mc_uids = []
+        avg_fweight = []
+        std_fweight = []
+
+        for uid in unq_uids:
+            mc_uids.append(uid)
+            w_tmp = []
+            for sub in weights:
+                idx = np.where(sub['uid'] == uid)[0]
+                if len(idx) != 0:
+                    w_tmp.append(sub['weights'][idx][0])
+                else:
+                    w_tmp.append(0.0)
+            avg_fweight.append(np.average(w_tmp))
+            std_fweight.append(np.std(w_tmp))
+
+        ascii.write([mc_uids, avg_fweight, std_fweight],
+                    f'{self.pahdbdir}/{self.galaxy}_{spectype}_mc_avg_fweights.txt',
+                    names=['#UID', 'avg_fweight', 'std_fweight'],
+                    overwrite=True)

--- a/amespahdbpythonsuite/mcfitted.py
+++ b/amespahdbpythonsuite/mcfitted.py
@@ -21,13 +21,6 @@ class MCfitted:
     def __init__(self, d: Optional[dict] = None, **keywords) -> None:
         self.__set(d, **keywords)
 
-    def set(self, d: Optional[dict] = None, **keywords) -> None:
-        """
-        Calls class: :class:`amespahdbpythonsuite.transitions.Transitions.set` to parse keywords.
-
-        """
-        self.__set(d, **keywords)
-
     def __set(self, d: Optional[dict] = None, **keywords) -> None:
         """
         Populate data dictionary helper.
@@ -37,13 +30,10 @@ class MCfitted:
             if d.get("type", "") == self.__class__.__name__:
                 if "mcfits" not in keywords:
                     self.mcfits = d["mcfits"]
-                if "mcpredicted" not in keywords:
-                    self.mcpredicted = d["mcpredicted"]
                 if "distribution" not in keywords:
                     self.distribuion = d["distribuion"]
 
         self.mcfits = keywords.get("mcfits", list())
-        self.mcpredicted = keywords.get("mcpredicted", False)
         self.distribution = keywords.get("distribution", "")
 
     def get(self) -> dict:
@@ -55,7 +45,6 @@ class MCfitted:
         d = {}
         d["type"] = self.__class__.__name__
         d["mcfits"] = self.mcfits
-        d["mcpredicted"] = self.mcpredicted
         d["distribution"] = self.distribution
 
         return d
@@ -130,11 +119,6 @@ class MCfitted:
             std_classes[key] = np.std(lst_classes[key], axis=0)
             components[key] = {'mean_spec': avg_classes[key], 'std_spec': std_classes[key]}
 
-        if 'predicted' in keywords:
-            avg_pred = np.mean(self.mcpredicted, axis=0)
-            std_pred = np.std(self.mcpredicted, axis=0)
-            components['predicted'] = {'mean_spec': avg_pred, 'std_spec': std_pred}
-
         return components
 
     def getfit(self, **keywords) -> list:
@@ -153,6 +137,7 @@ class MCfitted:
         Retrieves the breakdown of the MC fitted PAHs.
 
         """
+        results = dict()  # type: dict
         results = {'solo': [],
                    'duo': [],
                    'trio': [],
@@ -314,7 +299,7 @@ class MCfitted:
         if keywords.get('save'):
             if not isinstance(ptype, str):
                 ptype = 'fitted'
-            fig.savefig(f"mc_{ptype}_breakdown.pdf")
+            fig.savefig(f"{keywords['save']}mc_{ptype}_breakdown.pdf")
         else:
             plt.show()
 

--- a/amespahdbpythonsuite/mcfitted.py
+++ b/amespahdbpythonsuite/mcfitted.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
-import matplotlib.pyplot as plt
+import matplotlib.pyplot as plt  # type: ignore
 
 from amespahdbpythonsuite.amespahdb import AmesPAHdb
-from amespahdbpythonsuite.spectrum import Spectrum
 
 message = AmesPAHdb.message
 
@@ -27,7 +26,6 @@ class MCfitted:
         Calls class: :class:`amespahdbpythonsuite.transitions.Transitions.set` to parse keywords.
 
         """
-        Spectrum.set(self, d, **keywords)
         self.__set(d, **keywords)
 
     def __set(self, d: Optional[dict] = None, **keywords) -> None:
@@ -54,7 +52,7 @@ class MCfitted:
         Assigns class variables from inherited dictionary.
 
         """
-        d = Spectrum.get(self)
+        d = {}
         d["type"] = self.__class__.__name__
         d["mcfits"] = self.mcfits
         d["mcpredicted"] = self.mcpredicted

--- a/amespahdbpythonsuite/mcfitted.py
+++ b/amespahdbpythonsuite/mcfitted.py
@@ -1,27 +1,18 @@
 #!/usr/bin/env python3
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional, Union
+from typing import Optional
 
 import numpy as np
-
-from specutils import Spectrum1D, manipulation  # type: ignore
-from astropy.nddata import StdDevUncertainty  # type: ignore
-import astropy.units as u  # type: ignore
-from scipy import optimize  # type: ignore
+import matplotlib.pyplot as plt
 
 from amespahdbpythonsuite.amespahdb import AmesPAHdb
-from amespahdbpythonsuite.transitions import Transitions
-
-if TYPE_CHECKING:
-    from amespahdbpythonsuite.coadded import Coadded
-    from amespahdbpythonsuite.fitted import Fitted
-
+from amespahdbpythonsuite.spectrum import Spectrum
 
 message = AmesPAHdb.message
 
 
-class Mcfitted(Transitions):
+class Mcfitted(Spectrum):
     """
     AmesPAHdbPythonSuite mcfitted class.
     Contains methods to fit and plot the input spectrum using a Monte Carlo approach.
@@ -37,7 +28,7 @@ class Mcfitted(Transitions):
         Calls class: :class:`amespahdbpythonsuite.transitions.Transitions.set` to parse keywords.
 
         """
-        Transitions.set(self, d, **keywords)
+        Spectrum.set(self, d, **keywords)
         self.__set(d, **keywords)
 
     def __set(self, d: Optional[dict] = None, **keywords) -> None:
@@ -47,16 +38,25 @@ class Mcfitted(Transitions):
         """
         if isinstance(d, dict):
             if d.get("type", "") == self.__class__.__name__:
-                if "grid" not in keywords:
-                    self.grid = d["grid"]
-                if "profile" not in keywords:
-                    self.profile = d["profile"]
-                if "fwhm" not in keywords:
-                    self.fwhm = d["fwhm"]
+                if "observation" not in keywords:
+                    self.observation = d["observation"]
+                if "mcfits" not in keywords:
+                    self.mcfits = d["mcfits"]
+                if "mcweights" not in keywords:
+                    self.mcweights = d["mcweights"]
+                if "mcclasses" not in keywords:
+                    self.mcclasses = d["mcclasses"]
+                if "mcresults" not in keywords:
+                    self.mcresults = d["mcresults"]
+                if "mcpredicted" not in keywords:
+                    self.mcpredicted = d["mcpredicted"]
 
-        self.grid = keywords.get("grid", list())
-        self.profile = keywords.get("profile", "")
-        self.fwhm = keywords.get("fwhm", 0.0)
+        self.observation = keywords.get("observation", None)
+        self.mcfits = keywords.get("mcfits", list())
+        self.mcweights = keywords.get("mcweights", list())
+        self.mcclasses = keywords.get("mcclasses", list())
+        self.mcresults = keywords.get("mcresults", list())
+        self.mcpredicted = keywords.get("mcpredicted", False)
 
     def get(self) -> dict:
         """
@@ -64,17 +64,21 @@ class Mcfitted(Transitions):
         Assigns class variables from inherited dictionary.
 
         """
-        d = Transitions.get(self)
+        d = Spectrum.get(self)
         d["type"] = self.__class__.__name__
-        d["grid"] = self.grid
-        d["profile"] = self.profile
-        d["fwhm"] = self.fwhm
+        d["observation"] = self.observation
+        d["mcfits"] = self.mcfits
+        d["mcweights"] = self.mcweights
+        d["mcclasses"] = self.mcclasses
+        d["mcresults"] = self.mcresults
+        d["mcpredicted"] = self.mcpredicted
 
         return d
 
     def stats(self, results):
         """
-        Obtain statistics (min, max, median, mean, std) for the MC fitted parameters.
+        Obtain statistics (min, max, median, mean, std) for the MC fitted parameters,
+        and save to file.
 
         """
 
@@ -82,25 +86,34 @@ class Mcfitted(Transitions):
         o = open('mcfitted_statistics.txt', 'w')
         o.write('# param min max median mean std\n')
 
-        keys = list(results.keys())
-        for i, key in enumerate(keys):
-            if i < 5:
-                o.write(f'{key} {np.min(results[key]):d} {np.max(results[key]):d} {np.median(results[key]):.5f} {np.mean(results[key]):.5f} {np.std(results[key]):.5f}\n')
-            else:
-                o.write(f'{key} {np.min(results[key]):.5f} {np.max(results[key]):.5f} {np.median(results[key]):.5f} {np.mean(results[key]):.5f} {np.std(results[key]):.5f}\n')
+        rkeys = list(results.keys())
+        for i, key in enumerate(rkeys):
+            o.write(f'{key} {np.min(results[key]):.5f} '
+                    f'{np.max(results[key]):.5f} '
+                    f'{np.median(results[key]):.5f} '
+                    f'{np.mean(results[key]):.5f} '
+                    f'{np.std(results[key]):.5f}\n')
         o.close()
 
-    def averagespec(self, fits, classes, weights):
-        import pickle
+    def averagespec(self, mcfits, mcclasses, **keywords):
+        """
+        Calculate average and std spectra.
+
+        """
         #  Getting the average spectra
         components = {}
         lst_classes = {}
         avg_classes = {}
         std_classes = {}
 
-        # Average and std spectrum of fitted and predicted spectra.
-        avg_fit = np.mean(fits, axis=0)
-        std_fit = np.std(fits, axis=0)
+        # Average and std spectrum.
+        avg_fit = np.mean(mcfits, axis=0)
+        std_fit = np.std(mcfits, axis=0)
+
+        if 'mcpredicted' in keywords:
+            avg_pred = np.mean(self.mcpredicted, axis=0)
+            std_pred = np.std(self.mcpredicted, axis=0)
+            components['predicted'] = {'mean_spec': avg_pred, 'std_spec': std_pred}
 
         components['fit'] = {'mean_spec': avg_fit, 'std_spec': std_fit}
 
@@ -110,37 +123,130 @@ class Mcfitted(Transitions):
             lst_classes[key] = []
             avg_classes[key] = []
             std_classes[key] = []
-        for c in classes:
+        for c in mcclasses:
             for key in classkeys:
-                lst_classes[key].append(c[key])
+                if key in c.keys():
+                    lst_classes[key].append(c[key])
         for key in classkeys:
             avg_classes[key] = np.mean(lst_classes[key], axis=0)
             std_classes[key] = np.std(lst_classes[key], axis=0)
             components[key] = {'mean_spec': avg_classes[key], 'std_spec': std_classes[key]}
 
         # Dump average components pickle
-        pickle.dump(components, open('average_mc_spectra.pkl', 'wb'))
+        if 'dump' in keywords:
+            import pickle
+            pickle.dump(components, open('average_mc_spectra.pkl', 'wb'))
 
-        # Calculate average weights.
-        luids = [d['uid'] for d in weights]
-        unq_uids = np.unique([item for sublist in luids for item in sublist])
-        mc_uids = []
-        avg_fweight = []
-        std_fweight = []
+        return components
 
-        for uid in unq_uids:
-            mc_uids.append(uid)
-            w_tmp = []
-            for sub in weights:
-                idx = np.where(sub['uid'] == uid)[0]
-                if len(idx) != 0:
-                    w_tmp.append(sub['weights'][idx][0])
-                else:
-                    w_tmp.append(0.0)
-            avg_fweight.append(np.average(w_tmp))
-            std_fweight.append(np.std(w_tmp))
+    def plot(self, components, **keywords):
+        """
+        Plot the MC sampled fit and breakdown components.
 
-        ascii.write([mc_uids, avg_fweight, std_fweight],
-                    f'{self.pahdbdir}/{self.galaxy}_{spectype}_mc_avg_fweights.txt',
-                    names=['#UID', 'avg_fweight', 'std_fweight'],
-                    overwrite=True)
+        """
+
+        # Charge
+        fig, ax = plt.subplots()
+
+        if 'wavelength' in keywords:
+            x = 1e4 / self.grid
+            ax.set_xlim((min(x), max(x)))
+            xtitle = "Wavelength"
+        else:
+            x = self.grid
+            ax.set_xlim((max(x), min(x)))
+            xtitle = (
+                self.units["abscissa"]["label"]
+                + " ["
+                + self.units["abscissa"]["unit"].to_string("latex_inline")
+                + "]"
+            )
+
+        ax.minorticks_on()
+        ax.tick_params(which='major', right='on', top='on', direction='in', length=5)
+        ax.tick_params(which='minor', right='on', top='on', direction='in', length=3)
+        ax.set_xlim((min(x), max(x)))
+        ax.set_xlabel(f"{xtitle}")
+        ax.set_ylabel(
+            self.units["ordinate"]["label"]
+            + " ["
+            + self.units["ordinate"]["unit"].to_string("latex_inline")
+            + "]",
+        )
+
+        ax.errorbar(
+            x,
+            self.observation.spectrum.flux.value,
+            yerr=keywords["sigma"],
+            fmt="o",
+            mfc="white",
+            color="k",
+            ecolor="k",
+            markersize=3,
+            elinewidth=0.2,
+            capsize=0.8,
+            label="obs",
+        )
+
+        ax.plot(x, components['fit']['mean_spec'], color='tab:purple', linewidth=1.2, label='fit')
+        ax.fill_between(x, components['fit']['mean_spec'] - components['fit']['std_spec'],
+                        components['fit']['mean_spec'] + components['fit']['std_spec'],
+                        color='tab:purple', alpha=0.3)
+
+        if 'charge' in keywords:
+            if isinstance(components['anion']['mean_spec'], np.ndarray):
+                ax.plot(x, components['anion'], color='tab:red', linewidth=1.2, label='anion')
+                ax.fill_between(x, components['anion']['mean_spec'] - components['anion']['std_spec'],
+                                components['anion']['mean_spec'] + components['anion']['std_spec'],
+                                color='tab:red', alpha=0.3)
+
+            if isinstance(components['neutral']['mean_spec'], np.ndarray):
+                ax.plot(x, components['neutral']['mean_spec'], color='tab:green', linewidth=1.2, label='neutral')
+                ax.fill_between(x, components['neutral']['mean_spec'] - components['neutral']['std_spec'],
+                                components['neutral']['mean_spec'] + components['neutral']['std_spec'],
+                                color='tab:green', alpha=0.3)
+
+            if isinstance(components['cation']['mean_spec'], np.ndarray):
+                ax.plot(x, components['cation'], color='tab:blue', linewidth=1.2, label='cation')
+                ax.fill_between(x, components['cation']['mean_spec'] - components['cation']['std_spec'],
+                                components['cation']['mean_spec'] + components['cation']['std_spec'],
+                                color='tab:blue', alpha=0.3)
+
+        if 'size' in keywords:
+            if isinstance(components['small']['mean_spec'], np.ndarray):
+                ax.plot(x, components['small']['mean_spec'], color='tab:red', label='small')
+                ax.fill_between(x, components['small']['mean_spec'] - components['small']['std_spec'],
+                                components['small']['mean_spec'] + components['small']['std_spec'],
+                                color='tab:red', alpha=0.3)
+
+            if isinstance(components['large']['mean_spec'], np.ndarray):
+                ax.plot(x, components['large']['mean_spec'], color='tab:green', label='large')
+                ax.fill_between(x, components['large']['mean_spec'] - components['large']['std_spec'],
+                                components['large']['mean_spec'] + components['large']['std_spec'],
+                                color='tab:green', alpha=0.3)
+
+        if 'composition' in keywords:
+            if isinstance(components['pure']['mean_spec'], np.ndarray):
+                ax.plot(x, components['pure']['mean_spec'], color='tab:red', label='pure')
+                ax.fill_between(x, components['pure']['mean_spec'] - components['pure']['std_spec'],
+                                components['pure']['mean_spec'] + components['pure']['std_spec'],
+                                color='tab:red', alpha=0.3)
+
+            if isinstance(components['nitrogen']['mean_spec'], np.ndarray):
+                ax.plot(x, components['nitrogen']['mean_spec'], color='tab:green', label='nitrogen')
+                ax.fill_between(x, components['nitrogen']['mean_spec'] - components['nitrogen']['std_spec'],
+                                components['nitrogen']['mean_spec'] + components['nitrogen']['std_spec'],
+                                color='tab:green', alpha=0.3)
+
+        ax.axhline(0, linestyle='--', color='gray')
+        ax.legend(fontsize=12)
+
+        basename = keywords['ptype']
+        if basename:
+            if not isinstance(basename, str):
+                basename = 'fitted'
+            fig.savefig(f"mc_{keywords['ptype']}_breakdown.{keywords['ftype']}")
+        elif 'show' in keywords:
+            plt.show()
+
+        plt.close(fig)

--- a/amespahdbpythonsuite/mcfitted.py
+++ b/amespahdbpythonsuite/mcfitted.py
@@ -50,6 +50,8 @@ class Mcfitted(Spectrum):
                     self.mcresults = d["mcresults"]
                 if "mcpredicted" not in keywords:
                     self.mcpredicted = d["mcpredicted"]
+                if "method" not in keywords:
+                    self.method = d["method"]
 
         self.observation = keywords.get("observation", None)
         self.mcfits = keywords.get("mcfits", list())
@@ -57,6 +59,7 @@ class Mcfitted(Spectrum):
         self.mcclasses = keywords.get("mcclasses", list())
         self.mcresults = keywords.get("mcresults", list())
         self.mcpredicted = keywords.get("mcpredicted", False)
+        self.method = keywords.get("method", "")
 
     def get(self) -> dict:
         """
@@ -72,6 +75,7 @@ class Mcfitted(Spectrum):
         d["mcclasses"] = self.mcclasses
         d["mcresults"] = self.mcresults
         d["mcpredicted"] = self.mcpredicted
+        d["method"] = self.method
 
         return d
 

--- a/amespahdbpythonsuite/spectrum.py
+++ b/amespahdbpythonsuite/spectrum.py
@@ -16,6 +16,7 @@ from amespahdbpythonsuite.transitions import Transitions
 if TYPE_CHECKING:
     from amespahdbpythonsuite.coadded import Coadded
     from amespahdbpythonsuite.fitted import Fitted
+    from amespahdbpythonsuite.mcfitted import Mcfitted
 
 
 message = AmesPAHdb.message
@@ -363,7 +364,7 @@ class Spectrum(Transitions):
 
         self.grid = grid
 
-    def mcfit(self, obs, nsamples, **keywords):
+    def mcfit(self, obs, nsamples, **keywords) -> Mcfitted:
         """
         Monte Carlo sampling and fitting to the input spectrum.
 
@@ -375,9 +376,9 @@ class Spectrum(Transitions):
             int
 
         """
-        # Initialize lists and dictionaries.
         from amespahdbpythonsuite.mcfitted import Mcfitted
 
+        # Initialize lists and dictionaries.
         fits = []
         classes = []
         weights = []
@@ -396,6 +397,7 @@ class Spectrum(Transitions):
                    'nc': [],
                    'error': []
                    }
+
         keys = list(results.keys())
 
         if 'predict' in keywords:
@@ -420,9 +422,11 @@ class Spectrum(Transitions):
 
             # Obtain fit breakdown.
             bd = fit.getbreakdown()
-            error = fit.geterror()['err']
             for key in keys[:-1]:
                 results[key].append(bd[key])
+
+            # Obtain fit uncertainty.
+            error = fit.geterror()['err']
             results['error'].append(error)
 
             # Obtain classes.

--- a/amespahdbpythonsuite/spectrum.py
+++ b/amespahdbpythonsuite/spectrum.py
@@ -371,10 +371,8 @@ class Spectrum(Transitions):
         """
         Monte Carlo sampling and fitting to the input spectrum.
 
-        Properties
+        Parameters
         ----------
-        obs : observations object
-
         samples : Number of samples.
             int
 

--- a/amespahdbpythonsuite/spectrum.py
+++ b/amespahdbpythonsuite/spectrum.py
@@ -362,3 +362,68 @@ class Spectrum(Transitions):
             self.data[uid] = s.flux.value
 
         self.grid = grid
+
+    def mcfit(self, obs, nsamples, **keywords):
+        """
+        Perform Monte Carlo sampling and fit the spectrum.
+
+        Properties
+        ----------
+        obs : observations object
+
+        nsamples : Number of samples.
+            int
+
+        """
+        # Initialize lists and dictionaries.
+        import mcfitted
+
+        fits = []
+        classes = []
+        weights = []
+        results = {'solo': [],
+                   'duo': [],
+                   'trio': [],
+                   'quartet': [],
+                   'quintet': [],
+                   'avg_solo': [],
+                   'avg_duo': [],
+                   'avg_trio': [],
+                   'avg_quartet': [],
+                   'avg_quintet': [],
+                   'anion': [],
+                   'neutral': [],
+                   'cation': [],
+                   'small': [],
+                   'large': [],
+                   'nitrogen': [],
+                   'pure': [],
+                   'nc': [],
+                   'error': [],
+                   }
+        keys = list(results.keys())
+
+        # Start the MC sampling and fitting.
+        for i in range(len(nsamples)):
+            print(f'MC sampling {i+1}/{nsamples}')
+
+            # Calculate new flux based on random uniform distribution sampling
+            flux = np.random.normal(obs.spectrum.flux.value, obs.spectrum.uncertainty)
+
+            # Fit the spectrum
+            fit = self.fit(flux, obs.spectrum.uncertainty)
+
+            # Obtain the fit and weights.
+            fits.append(fit.getfit())
+            weights.append(fit.weights())
+
+            # Obtain fit breakdown
+            bd = fit.getbreakdown()
+            for key in keys[:-2]:
+                results[key].append(bd[key])
+
+            # Obtain classes
+            classes.append(fit.getclasses())
+
+        if keywords.get("stats", False):
+            mcfitted.stats(results)

--- a/amespahdbpythonsuite/tests/test_mcfitted.py
+++ b/amespahdbpythonsuite/tests/test_mcfitted.py
@@ -6,9 +6,6 @@ Test the mcfitted.py module.
 """
 
 import pytest
-from os.path import exists
-import numpy as np
-import matplotlib.pyplot as plt
 
 from pkg_resources import resource_filename
 

--- a/amespahdbpythonsuite/tests/test_mcfitted.py
+++ b/amespahdbpythonsuite/tests/test_mcfitted.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+test_mcfitted.py
+
+Test the mcfitted.py module.
+"""
+
+import pytest
+from os.path import exists
+import numpy as np
+import matplotlib.pyplot as plt
+
+from pkg_resources import resource_filename
+
+from amespahdbpythonsuite.amespahdb import AmesPAHdb
+from amespahdbpythonsuite import mcfitted, observation
+
+
+@pytest.fixture(scope="module")
+def test_mcfitted():
+    xml = "resources/pahdb-theoretical_cutdown.xml"
+    db = AmesPAHdb(
+        filename=resource_filename("amespahdbpythonsuite", xml),
+        check=False,
+        cache=False,
+        update=False,
+    )
+    uids = [18, 73, 726, 2054, 223]
+    transitions = db.gettransitionsbyuid(uids)
+    transitions.cascade(6 * 1.603e-12, multiprocessing=False)
+    transitions.shift(-15.0)
+    obs = observation.Observation(
+        resource_filename("amespahdbpythonsuite", "resources/galaxy_spec.ipac")
+    )
+    spectrum = transitions.convolve(
+        grid=1e4 / obs.getgrid(), fwhm=15.0, gaussian=True, multiprocessing=False
+    )
+
+    return spectrum.mcfit(obs, nsamples=10)
+
+
+class TestMcfitted:
+    """
+    Test Spectrum class.
+
+    """
+
+    def test_instance(self):
+        assert isinstance(mcfitted.Mcfitted(), mcfitted.Mcfitted)

--- a/amespahdbpythonsuite/tests/test_mcfitted.py
+++ b/amespahdbpythonsuite/tests/test_mcfitted.py
@@ -43,4 +43,4 @@ class TestMcfitted:
     """
 
     def test_instance(self):
-        assert isinstance(mcfitted.Mcfitted(), mcfitted.Mcfitted)
+        assert isinstance(mcfitted.MCfitted(), mcfitted.MCfitted)

--- a/amespahdbpythonsuite/tests/test_mcfitted.py
+++ b/amespahdbpythonsuite/tests/test_mcfitted.py
@@ -6,11 +6,13 @@ Test the mcfitted.py module.
 """
 
 import pytest
+from os.path import exists
+import matplotlib.pyplot as plt
 
 from pkg_resources import resource_filename
 
 from amespahdbpythonsuite.amespahdb import AmesPAHdb
-from amespahdbpythonsuite import mcfitted, observation
+from amespahdbpythonsuite import observation, mcfitted
 
 
 @pytest.fixture(scope="module")
@@ -36,6 +38,13 @@ def test_mcfitted():
     return spectrum.mcfit(obs, nsamples=10)
 
 
+@pytest.fixture(scope="module")
+def test_path(tmp_path_factory):
+    d = tmp_path_factory.mktemp("test_mcfitted")
+    print(d)
+    return f"{d}/"
+
+
 class TestMcfitted:
     """
     Test Spectrum class.
@@ -44,3 +53,35 @@ class TestMcfitted:
 
     def test_instance(self):
         assert isinstance(mcfitted.MCfitted(), mcfitted.MCfitted)
+
+    def test_plot(self, monkeypatch, test_mcfitted):
+        monkeypatch.setattr(plt, "show", lambda: None)
+        test_mcfitted.plot(show=True)
+
+    def test_stats(self, test_mcfitted, test_path):
+        test_mcfitted.getstats(save=True)
+        assert exists('mcfitted_statistics.txt')
+
+    def test_plot_charge(self, test_mcfitted, test_path):
+        test_mcfitted.plot(
+            wavelength=True,
+            charge=True,
+            save=test_path,
+        )
+        assert exists(f"{test_path}mc_charge_breakdown.pdf")
+
+    def test_plot_size(self, test_mcfitted, test_path):
+        test_mcfitted.plot(
+            wavelength=True,
+            size=True,
+            save=test_path,
+        )
+        assert exists(f"{test_path}mc_size_breakdown.pdf")
+
+    def test_plot_composition(self, test_mcfitted, test_path):
+        test_mcfitted.plot(
+            wavelength=True,
+            composition=True,
+            save=test_path,
+        )
+        assert exists(f"{test_path}mc_composition_breakdown.pdf")

--- a/amespahdbpythonsuite/tests/test_spectrum.py
+++ b/amespahdbpythonsuite/tests/test_spectrum.py
@@ -138,6 +138,6 @@ class TestSpectrum:
             gaussian=True,
             multiprocessing=False,
         )
-        mcfit = spectrum.mcfit(obs, nsamples=10)
+        mcfit = spectrum.mcfit(obs, samples=10)
         assert mcfit.method == 'NNLC'
         assert len(mcfit.mcfits) == 10

--- a/amespahdbpythonsuite/tests/test_spectrum.py
+++ b/amespahdbpythonsuite/tests/test_spectrum.py
@@ -128,3 +128,16 @@ class TestSpectrum:
     def test_write_spectrum(self, test_spectrum, test_path):
         test_spectrum.write(f"{test_path}.tbl")
         assert exists(f"{test_path}.tbl")
+
+    def test_mcfit(self, test_transitions):
+        file = resource_filename("amespahdbpythonsuite", "resources/galaxy_spec.ipac")
+        obs = observation.Observation(file)
+        spectrum = test_transitions.convolve(
+            grid=1e4 / obs.spectrum.spectral_axis.value,
+            fwhm=15.0,
+            gaussian=True,
+            multiprocessing=False,
+        )
+        mcfit = spectrum.mcfit(obs, nsamples=10)
+        assert mcfit.method == 'NNLC'
+        assert len(mcfit.mcfits) == 10

--- a/amespahdbpythonsuite/tests/test_spectrum.py
+++ b/amespahdbpythonsuite/tests/test_spectrum.py
@@ -139,5 +139,5 @@ class TestSpectrum:
             multiprocessing=False,
         )
         mcfit = spectrum.mcfit(obs, samples=10)
-        assert mcfit.method == 'NNLC'
+        assert mcfit.mcfits[0].method == 'NNLC'
         assert len(mcfit.mcfits) == 10

--- a/examples/example_mc_fit_a_spectrum.py
+++ b/examples/example_mc_fit_a_spectrum.py
@@ -45,20 +45,12 @@ if __name__ == '__main__':
     spectrum = transitions.convolve(grid=1e4 / obs.getgrid(), fwhm=15.0, gaussian=True, multiprocessing=False)
 
     # Fit the spectrum using Monte Carlo approach.
-    mcfit = spectrum.mcfit(obs, nsamples=10)
+    mcfit = spectrum.mcfit(obs, samples=1024, notice=False)
 
     # Get average/min/max/std statistics for the breakdown components and uncertainty, and save to file.
-    mcfit.stats(mcfit.mcresults)
-
-    # Get average and std spectra and dump them into pickle.
-    mccomponents = mcfit.averagespec(mcfit.mcfits, mcfit.mcclasses, dump=True)
+    mcfit.getstats(save=True)
 
     # Create plots.
-    mcfit.plot(mccomponents, wavelength=True, sigma=obs.spectrum.uncertainty.array,
-               ptype='charge', ftype='pdf')
-
-    mcfit.plot(mccomponents, wavelength=True, sigma=obs.spectrum.uncertainty.array,
-               ptype='size', ftype='pdf')
-
-    mcfit.plot(mccomponents, wavelength=True, sigma=obs.spectrum.uncertainty.array,
-               ptype='composition', ftype='pdf')
+    mcfit.plot(wavelength=True, charge=True, save=True)
+    mcfit.plot(wavelength=True, size=True, save=True)
+    mcfit.plot(wavelength=True, composition=True, save=True)

--- a/examples/example_mc_fit_a_spectrum.py
+++ b/examples/example_mc_fit_a_spectrum.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""example2.py
+
+Example of using the AmesPAHdbPythonSuite to display the ('stick')
+absorption spectrum of coronene (UID=18).
+
+For more examples visit the PAHdb cookbook website:
+https://pahdb.github.io/cookbook/
+
+"""
+
+from pkg_resources import resource_filename
+
+from amespahdbpythonsuite.amespahdb import AmesPAHdb
+from amespahdbpythonsuite import observation
+
+if __name__ == '__main__':
+
+    obs = observation.Observation(
+        resource_filename("amespahdbpythonsuite", "resources/galaxy_spec.ipac")
+    )
+    # Read the database.
+    xml = 'resources/pahdb-theoretical_cutdown.xml'
+    pahdb = AmesPAHdb(filename=resource_filename('amespahdbpythonsuite', xml),
+                      check=False, cache=False)
+
+    uids = pahdb.search("magnesium=0 oxygen=0 iron=0 silicium=0 chx=0 ch2=0 c>20 h>0")
+
+    # Put back fullerenes, which have h=0
+    fullerenes = [717, 720, 723, 735, 736, 737]
+
+    uids = uids + fullerenes
+
+    # Retrieve the transitions from the database for the subset of PAHs.
+    transitions = pahdb.gettransitionsbyuid([uids])
+
+    # Calculate the emission spectrum at the temperature reached
+    # after absorbing a 6 eV (CGS units) photon.
+    transitions.cascade(6 * 1.603e-12, multiprocessing=False)
+
+    # Shift data 15 wavenumber to the red
+    transitions.shift(-15.0)
+
+    # Convolve the bands with a Gaussian with FWHM of 15 /cm.
+    spectrum = transitions.convolve(grid=1e4 / obs.getgrid(), fwhm=15.0, gaussian=True, multiprocessing=False)
+
+    # Fit the spectrum using Monte Carlo approach.
+    mcfit = spectrum.mcfit(obs, nsamples=10)
+
+    # Get average/min/max/std statistics for the breakdown components and uncertainty, and save to file.
+    mcfit.stats(mcfit.mcresults)
+
+    # Get average and std spectra and dump them into pickle.
+    mccomponents = mcfit.averagespec(mcfit.mcfits, mcfit.mcclasses, dump=True)
+
+    # Create plots.
+    mcfit.plot(mccomponents, wavelength=True, sigma=obs.spectrum.uncertainty.array,
+               ptype='charge', ftype='pdf')
+
+    mcfit.plot(mccomponents, wavelength=True, sigma=obs.spectrum.uncertainty.array,
+               ptype='size', ftype='pdf')
+
+    mcfit.plot(mccomponents, wavelength=True, sigma=obs.spectrum.uncertainty.array,
+               ptype='composition', ftype='pdf')

--- a/examples/example_mc_fit_a_spectrum.py
+++ b/examples/example_mc_fit_a_spectrum.py
@@ -9,6 +9,7 @@ https://pahdb.github.io/cookbook/
 
 """
 
+import os
 from pkg_resources import resource_filename
 
 from amespahdbpythonsuite.amespahdb import AmesPAHdb
@@ -48,9 +49,9 @@ if __name__ == '__main__':
     mcfit = spectrum.mcfit(obs, samples=1024, notice=False)
 
     # Get average/min/max/std statistics for the breakdown components and uncertainty, and save to file.
-    mcfit.getstats(save=True)
+    mcfit.getstats(save=False)
 
     # Create plots.
-    mcfit.plot(wavelength=True, charge=True, save=True)
-    mcfit.plot(wavelength=True, size=True, save=True)
-    mcfit.plot(wavelength=True, composition=True, save=True)
+    mcfit.plot(wavelength=True, charge=True, save=os.getcwd())
+    mcfit.plot(wavelength=True, size=True, save=os.getcwd())
+    mcfit.plot(wavelength=True, composition=True, save=os.getcwd())


### PR DESCRIPTION
This is a draft PR which adds Monte Carlo fitting implementation. It includes:
- `mcfitted.py` module.
- `mcfit` method in spectrum.py.
- `example_mc_fit_a_spectrum.py`, example file for Monte Carlo usage.
- test of the `mcfit` method.

Pending:
- `test_mcfitted.py` tests
- allow coadded option when using the Monte Carlo method.
- rebase to include the 1 commit from PAHdb:master.

This PR is currently marked as `draft` to discuss the current and future implementations.