### PR TITLE
Update fitted.py plotting and mcfit example

### DIFF
--- a/amespahdbpythonsuite/fitted.py
+++ b/amespahdbpythonsuite/fitted.py
@@ -114,12 +114,9 @@ class Fitted(Spectrum):
                     label="obs",
                 )
             else:
-                axis[0].scatter(x,
-                                self.observation.flux.value,
-                                color="k",
-                                s=5,
-                                label="obs"
-                               )
+                axis[0].scatter(
+                    x, self.observation.flux.value, color="k", s=5, label="obs"
+                )
 
             if "title" in keywords:
                 axis[0].set_title(keywords["title"])
@@ -214,7 +211,7 @@ class Fitted(Spectrum):
                 axis[0].set_xlabel(f"{xtitle} ({keywords['units'][0]})")
 
         if keywords.get("save", False):
-            if not keywords.get('ptype'):
+            if not keywords.get("ptype"):
                 ptype = "fitted"
             else:
                 ptype = f"{keywords['ptype']}"

--- a/amespahdbpythonsuite/fitted.py
+++ b/amespahdbpythonsuite/fitted.py
@@ -99,7 +99,7 @@ class Fitted(Spectrum):
                     + "]"
                 )
 
-            if isinstance(keywords["sigma"], (list, tuple, np.ndarray)):
+            if "sigma" in keywords:
                 axis[0].errorbar(
                     x,
                     self.observation.flux.value,
@@ -132,11 +132,7 @@ class Fitted(Spectrum):
             colors = cm.rainbow(np.linspace(0, 1, len(self.uids)))
             for uid, col in zip(self.uids, colors):
                 y = self.data[uid]
-                if (
-                    keywords.get("charge", True)
-                    and keywords.get("size", True)
-                    and keywords.get("composition", False)
-                ):
+                if keywords.get("residual", False):
                     axis[0].plot(x, y, color=col)
 
             axis[0].plot(x, self.getfit(), color="tab:purple", label="fit")

--- a/amespahdbpythonsuite/fitted.py
+++ b/amespahdbpythonsuite/fitted.py
@@ -93,7 +93,7 @@ class Fitted(Spectrum):
             if keywords.get("wavelength", False):
                 x = 1e4 / self.grid
                 axis[0].set_xlim((min(x), max(x)))
-                xtitle = "Wavelength"
+                xtitle = "Wavelength [$\\mu$m]"
             else:
                 x = self.grid
                 axis[0].set_xlim((max(x), min(x)))
@@ -201,7 +201,7 @@ class Fitted(Spectrum):
                 + "]",
             )
             if keywords.get("residual", False):
-                axis[1].set_xlabel(f"{xtitle} ({keywords['units'][0]})")
+                axis[1].set_xlabel(f"{xtitle}")
                 axis[1].set_ylabel("residual")
                 axis[1].minorticks_on()
                 axis[1].tick_params(
@@ -211,13 +211,19 @@ class Fitted(Spectrum):
                     which="minor", right="on", top="on", direction="in", length=3
                 )
             else:
-                axis[0].set_xlabel(f"{xtitle} ({keywords['units'][0]})")
+                axis[0].set_xlabel(f"{xtitle}")
 
         if keywords.get("save", False):
-            if not keywords.get("ptype"):
-                ptype = "fitted"
+            if keywords.get("charge"):
+                ptype = "charge"
+            elif keywords.get("size"):
+                ptype = "size"
+            elif keywords.get("composition"):
+                ptype = "composition"
+            elif keywords.get("residual"):
+                ptype = "residual"
             else:
-                ptype = f"{keywords['ptype']}"
+                ptype = "fitted"
 
             if keywords["output"]:
                 if os.path.isdir(keywords["output"]):

--- a/amespahdbpythonsuite/fitted.py
+++ b/amespahdbpythonsuite/fitted.py
@@ -2,6 +2,7 @@
 
 from typing import Optional, Union, Literal
 
+import os
 import builtins
 import operator
 import numpy as np
@@ -98,19 +99,27 @@ class Fitted(Spectrum):
                     + "]"
                 )
 
-            axis[0].errorbar(
-                x,
-                self.observation.flux.value,
-                yerr=keywords["sigma"],
-                fmt="o",
-                mfc="white",
-                color="k",
-                ecolor="k",
-                markersize=3,
-                elinewidth=0.2,
-                capsize=0.8,
-                label="obs",
-            )
+            if isinstance(keywords["sigma"], (list, tuple, np.ndarray)):
+                axis[0].errorbar(
+                    x,
+                    self.observation.flux.value,
+                    yerr=keywords["sigma"],
+                    fmt="o",
+                    mfc="white",
+                    color="k",
+                    ecolor="k",
+                    markersize=3,
+                    elinewidth=0.2,
+                    capsize=0.8,
+                    label="obs",
+                )
+            else:
+                axis[0].scatter(x,
+                                self.observation.flux.value,
+                                color="k",
+                                s=5,
+                                label="obs"
+                               )
 
             if "title" in keywords:
                 axis[0].set_title(keywords["title"])
@@ -204,12 +213,20 @@ class Fitted(Spectrum):
             else:
                 axis[0].set_xlabel(f"{xtitle} ({keywords['units'][0]})")
 
-        basename = keywords.get("save")
-        if basename:
-            if not isinstance(basename, str):
-                basename = "fitted"
-            fig.savefig(f"{basename}_{keywords['ptype']}.{keywords['ftype']}")
-        elif keywords.get("show", False):
+        if keywords.get("save", False):
+            if not keywords.get('ptype'):
+                ptype = "fitted"
+            else:
+                ptype = f"{keywords['ptype']}"
+
+            if keywords["output"]:
+                if os.path.isdir(keywords["output"]):
+                    fig.savefig(f"{keywords['output']}/{ptype}.{keywords['ftype']}")
+                else:
+                    fig.savefig(f"{keywords['output']}_{ptype}.{keywords['ftype']}")
+            else:
+                fig.savefig(f"{ptype}.{keywords['ftype']}")
+        else:
             plt.show()
         plt.close(fig)
 

--- a/amespahdbpythonsuite/fitted.py
+++ b/amespahdbpythonsuite/fitted.py
@@ -41,6 +41,11 @@ class Fitted(Spectrum):
         import matplotlib.gridspec as gs  # type: ignore
         import matplotlib.cm as cm  # type: ignore
 
+        if keywords.get("datalabel", False):
+            datalabel = keywords["datalabel"]
+        else:
+            datalabel = "obs"
+
         if keywords.get("sizedistribution", False):
             fig, axis = plt.subplots()
             axis = [axis]
@@ -111,11 +116,11 @@ class Fitted(Spectrum):
                     markersize=3,
                     elinewidth=0.2,
                     capsize=0.8,
-                    label="obs",
+                    label=datalabel,
                 )
             else:
                 axis[0].scatter(
-                    x, self.observation.flux.value, color="k", s=5, label="obs"
+                    x, self.observation.flux.value, color="k", s=5, label=datalabel
                 )
 
             if "title" in keywords:
@@ -169,6 +174,8 @@ class Fitted(Spectrum):
             elif keywords.get("residual", False):
                 y = self.getresidual()
                 axis[1].plot(x, y)
+                axis[1].axhline(0, linestyle="--", color="gray")
+                axis[0].legend()
             else:
                 axis[1].text(
                     0.05,

--- a/amespahdbpythonsuite/tests/test_fitted.py
+++ b/amespahdbpythonsuite/tests/test_fitted.py
@@ -94,14 +94,13 @@ class TestFitted:
             sigma=test_fitted.observation.uncertainty.array,
             save=True,
             output=test_path,
-            ptype="UIDs",
             ftype="pdf",
             units=[
                 test_fitted.observation.spectral_axis.unit.to_string(),
                 test_fitted.observation.flux.unit.to_string(),
             ],
         )
-        assert exists(f"{test_path}_UIDs.pdf")
+        assert exists(f"{test_path}_fitted.pdf")
 
     def test_plot_residual(self, test_fitted, test_path):
         test_fitted.plot(
@@ -110,7 +109,6 @@ class TestFitted:
             sigma=test_fitted.observation.uncertainty.array,
             save=True,
             output=test_path,
-            ptype="residual",
             ftype="pdf",
             units=[
                 test_fitted.observation.spectral_axis.unit.to_string(),
@@ -126,7 +124,6 @@ class TestFitted:
             sigma=test_fitted.observation.uncertainty.array,
             save=True,
             output=test_path,
-            ptype="size",
             ftype="pdf",
             units=[
                 test_fitted.observation.spectral_axis.unit.to_string(),
@@ -142,7 +139,6 @@ class TestFitted:
             sigma=test_fitted.observation.uncertainty.array,
             save=True,
             output=test_path,
-            ptype="charge",
             ftype="pdf",
             units=[
                 test_fitted.observation.spectral_axis.unit.to_string(),
@@ -158,7 +154,6 @@ class TestFitted:
             sigma=test_fitted.observation.uncertainty.array,
             save=True,
             output=test_path,
-            ptype="composition",
             ftype="pdf",
             units=[
                 test_fitted.observation.spectral_axis.unit.to_string(),

--- a/amespahdbpythonsuite/tests/test_fitted.py
+++ b/amespahdbpythonsuite/tests/test_fitted.py
@@ -92,7 +92,8 @@ class TestFitted:
         test_fitted.plot(
             wavelength=True,
             sigma=test_fitted.observation.uncertainty.array,
-            save=test_path,
+            save=True,
+            output=test_path,
             ptype="UIDs",
             ftype="pdf",
             units=[
@@ -107,7 +108,8 @@ class TestFitted:
             wavelength=True,
             residual=True,
             sigma=test_fitted.observation.uncertainty.array,
-            save=test_path,
+            save=True,
+            output=test_path,
             ptype="residual",
             ftype="pdf",
             units=[
@@ -122,7 +124,8 @@ class TestFitted:
             wavelength=True,
             size=True,
             sigma=test_fitted.observation.uncertainty.array,
-            save=test_path,
+            save=True,
+            output=test_path,
             ptype="size",
             ftype="pdf",
             units=[
@@ -137,7 +140,8 @@ class TestFitted:
             wavelength=True,
             charge=True,
             sigma=test_fitted.observation.uncertainty.array,
-            save=test_path,
+            save=True,
+            output=test_path,
             ptype="charge",
             ftype="pdf",
             units=[
@@ -152,7 +156,8 @@ class TestFitted:
             wavelength=True,
             composition=True,
             sigma=test_fitted.observation.uncertainty.array,
-            save=test_path,
+            save=True,
+            output=test_path,
             ptype="composition",
             ftype="pdf",
             units=[

--- a/examples/example_mc_fit_a_spectrum.py
+++ b/examples/example_mc_fit_a_spectrum.py
@@ -19,11 +19,7 @@ if __name__ == "__main__":
         resource_filename("amespahdbpythonsuite", "resources/galaxy_spec.ipac")
     )
 
-    # Store units for plotting.
-    units = [obs.spectrum.spectral_axis.unit.to_string(),
-             obs.spectrum.flux.unit.to_string()]
-
-    # Convert spectral unit to wavenumber.
+    # Convert spectral unit to wavenumber required by AmesPAHdbPythonSuite.
     obs.abscissaunitsto("1/cm")
 
     # Read the database.
@@ -55,7 +51,7 @@ if __name__ == "__main__":
     mcfit = spectrum.mcfit(obs, samples=1024, multiprocessing=False)
 
     # Create plots.
-    mcfit.plot(wavelength=True, charge=True, ptype='charge', units=units)
-    mcfit.plot(wavelength=True, size=True, ptype='size', units=units)
-    mcfit.plot(wavelength=True, composition=True, ptype='composition', units=units)
-    mcfit.plot(wavelength=True, units=units, save=True, ftype='pdf')
+    mcfit.plot(wavelength=True, charge=True)
+    mcfit.plot(wavelength=True, size=True)
+    mcfit.plot(wavelength=True, composition=True)
+    mcfit.plot(wavelength=True, save=True, ftype='pdf')

--- a/examples/example_mc_fit_a_spectrum.py
+++ b/examples/example_mc_fit_a_spectrum.py
@@ -19,7 +19,11 @@ if __name__ == "__main__":
         resource_filename("amespahdbpythonsuite", "resources/galaxy_spec.ipac")
     )
 
-    # Convert spectral unit to wavenumber
+    # Store units for plotting.
+    units = [obs.spectrum.spectral_axis.unit.to_string(),
+             obs.spectrum.flux.unit.to_string()]
+
+    # Convert spectral unit to wavenumber.
     obs.abscissaunitsto("1/cm")
 
     # Read the database.
@@ -37,7 +41,7 @@ if __name__ == "__main__":
 
     # Calculate the emission spectrum at the temperature reached
     # after absorbing a 6 eV (CGS units) photon.
-    # transitions.cascade(6 * 1.603e-12, multiprocessing=False)
+    transitions.cascade(6 * 1.603e-12, multiprocessing=False)
 
     # Shift data 15 wavenumber to the red to mimic some effects of anharmonicity.
     transitions.shift(-15.0)
@@ -51,6 +55,7 @@ if __name__ == "__main__":
     mcfit = spectrum.mcfit(obs, samples=1024, multiprocessing=False)
 
     # Create plots.
-    mcfit.plot(wavelength=True, charge=True)
-    mcfit.plot(wavelength=True, size=True)
-    mcfit.plot(wavelength=True, composition=True)
+    mcfit.plot(wavelength=True, charge=True, ptype='charge', units=units)
+    mcfit.plot(wavelength=True, size=True, ptype='size', units=units)
+    mcfit.plot(wavelength=True, composition=True, ptype='composition', units=units)
+    mcfit.plot(wavelength=True, units=units, save=True, ftype='pdf')


### PR DESCRIPTION
Updates for the plotting methods in fitted.py to allow plotting when no observational uncertainties are given, and proper handling of user keywords. 

Specifically:
- if `save=True` the plot will be saved in the current directory.
- if `save=True` and `output` keyword is provided it will check to see if `output` is a directory to save the plot or an output filename that can also contain the destination directory.
- if no `save` keyword is provided it will `plt.show()` without requiring a `show=True` keyword.

`test_fitted.py` has been updated to reflect the changes, and `example_mc_fit_a_spectrum.py` is updated to include the units and ptype arguments and give a `save=True` example.